### PR TITLE
Add public proxy service

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -17,3 +17,14 @@ services:
     environment:
       - POSTGRES_DB=unleash_development
       - POSTGRES_HOST_AUTH_METHOD=trust
+  artsy-unleash-proxy:
+    image: unleashorg/unleash-proxy
+    environment:
+      - PORT=4242
+      - UNLEASH_API_TOKEN=REPLACE_ME
+      - UNLEASH_PROXY_SECRETS=some-secret
+      - UNLEASH_URL=http://artsy-unleash:8080/api/
+    ports:
+      - 4242:4242
+    depends_on:
+      - artsy-unleash

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -2,10 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ project_name }}-web
+  name: artsy-unleash-web
   namespace: default
   labels:
-    app: {{ project_name }}
+    app: artsy-unleash
     component: web
     layer: application
 spec:
@@ -16,25 +16,25 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: {{ project_name }}
+      app: artsy-unleash
       component: web
       layer: application
   template:
     metadata:
       labels:
-        app: {{ project_name }}
+        app: artsy-unleash
         component: web
         layer: application
-      name: {{ project_name }}-web
+      name: artsy-unleash-web
     spec:
       containers:
-        - name: {{ project_name }}-web
+        - name: artsy-unleash-web
           env:
             - name: HTTP_PORT
               value: '8080'
           envFrom:
             - configMapRef:
-                name: {{ project_name }}-environment
+                name: artsy-unleash-environment
           image: {{ project_repo }}:production
           imagePullPolicy: Always
           ports:
@@ -50,10 +50,7 @@ spec:
           readinessProbe:
             httpGet:
               port: unleash-http
-              path: /health/ping
-              httpHeaders:
-                - name: X-Forwarded-Proto
-                  value: https
+              path: /
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -80,13 +77,13 @@ spec:
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ project_name }}-web
+  name: artsy-unleash-web
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ project_name }}-web
+    name: artsy-unleash-web
   minReplicas: 2
   maxReplicas: 2
   targetCPUUtilizationPercentage: 70
@@ -96,10 +93,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ project_name }}
+    app: artsy-unleash
     component: web
     layer: application
-  name: {{ project_name }}-web-internal
+  name: artsy-unleash-web-internal
   namespace: default
 spec:
   ports:
@@ -108,7 +105,7 @@ spec:
       name: http
       targetPort: unleash-http
   selector:
-    app: {{ project_name }}
+    app: artsy-unleash
     layer: application
     component: web
   type: ClusterIP
@@ -117,7 +114,7 @@ spec:
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ project_name }}
+  name: artsy-unleash
   annotations:
 spec:
   ingressClassName: nginx-internal
@@ -128,5 +125,135 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {{ project_name }}-web-internal
+              serviceName: artsy-unleash-web-internal
               servicePort: http
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: artsy-unleash-proxy-web
+  namespace: default
+  labels:
+    app: artsy-unleash-proxy
+    component: web
+    layer: application
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: artsy-unleash-proxy
+      component: web
+      layer: application
+  template:
+    metadata:
+      labels:
+        app: artsy-unleash-proxy
+        component: web
+        layer: application
+      name: artsy-unleash-proxy-web
+    spec:
+      containers:
+        - name: artsy-unleash-proxy-web
+          env:
+            - name: PORT
+              value: '4242'
+          envFrom:
+            - configMapRef:
+                name: artsy-unleash-proxy-environment
+          image: unleashorg/unleash-proxy
+          imagePullPolicy: Always
+          ports:
+            # k8s limits a port name to 15 characters
+            - name: unleashprx-http
+              containerPort: 4242
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              port: unleashprx-http
+              path: /proxy/health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: tier
+                  operator: In
+                  values:
+                    - foreground
+
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: artsy-unleash-proxy-web
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: artsy-unleash-proxy-web
+  minReplicas: 1
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 70
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: artsy-unleash-proxy
+    component: web
+    layer: application
+  name: artsy-unleash-proxy-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 4242
+      protocol: TCP
+      name: prx-http
+      targetPort: unleashprx-http
+  selector:
+    app: artsy-unleash-proxy
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: artsy-unleash-proxy
+  annotations:
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: unleashprx.artsy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: artsy-unleash-proxy-web-internal
+              servicePort: prx-http

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -2,10 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ project_name }}-web
+  name: artsy-unleash-web
   namespace: default
   labels:
-    app: {{ project_name }}
+    app: artsy-unleash
     component: web
     layer: application
 spec:
@@ -16,25 +16,25 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: {{ project_name }}
+      app: artsy-unleash
       component: web
       layer: application
   template:
     metadata:
       labels:
-        app: {{ project_name }}
+        app: artsy-unleash
         component: web
         layer: application
-      name: {{ project_name }}-web
+      name: artsy-unleash-web
     spec:
       containers:
-        - name: {{ project_name }}-web
+        - name: artsy-unleash-web
           env:
             - name: HTTP_PORT
               value: '8080'
           envFrom:
             - configMapRef:
-                name: {{ project_name }}-environment
+                name: artsy-unleash-environment
           image: {{ project_repo }}:staging
           imagePullPolicy: Always
           ports:
@@ -50,10 +50,7 @@ spec:
           readinessProbe:
             httpGet:
               port: unleash-http
-              path: /health/ping
-              httpHeaders:
-                - name: X-Forwarded-Proto
-                  value: https
+              path: /
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -80,13 +77,13 @@ spec:
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ project_name }}-web
+  name: artsy-unleash-web
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ project_name }}-web
+    name: artsy-unleash-web
   minReplicas: 1
   maxReplicas: 2
   targetCPUUtilizationPercentage: 70
@@ -96,10 +93,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ project_name }}
+    app: artsy-unleash
     component: web
     layer: application
-  name: {{ project_name }}-web-internal
+  name: artsy-unleash-web-internal
   namespace: default
 spec:
   ports:
@@ -108,7 +105,7 @@ spec:
       name: http
       targetPort: unleash-http
   selector:
-    app: {{ project_name }}
+    app: artsy-unleash
     layer: application
     component: web
   type: ClusterIP
@@ -117,7 +114,7 @@ spec:
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ project_name }}
+  name: artsy-unleash
   annotations:
 spec:
   ingressClassName: nginx-internal
@@ -128,5 +125,135 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {{ project_name }}-web-internal
+              serviceName: artsy-unleash-web-internal
               servicePort: http
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: artsy-unleash-proxy-web
+  namespace: default
+  labels:
+    app: artsy-unleash-proxy
+    component: web
+    layer: application
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: artsy-unleash-proxy
+      component: web
+      layer: application
+  template:
+    metadata:
+      labels:
+        app: artsy-unleash-proxy
+        component: web
+        layer: application
+      name: artsy-unleash-proxy-web
+    spec:
+      containers:
+        - name: artsy-unleash-proxy-web
+          env:
+            - name: PORT
+              value: '4242'
+          envFrom:
+            - configMapRef:
+                name: artsy-unleash-proxy-environment
+          image: unleashorg/unleash-proxy
+          imagePullPolicy: Always
+          ports:
+            # k8s limits a port name to 15 characters
+            - name: unleashprx-http
+              containerPort: 4242
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              port: unleashprx-http
+              path: /proxy/health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: tier
+                  operator: In
+                  values:
+                    - foreground
+
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: artsy-unleash-proxy-web
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: artsy-unleash-proxy-web
+  minReplicas: 1
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 70
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: artsy-unleash-proxy
+    component: web
+    layer: application
+  name: artsy-unleash-proxy-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 4242
+      protocol: TCP
+      name: prx-http
+      targetPort: unleashprx-http
+  selector:
+    app: artsy-unleash-proxy
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: artsy-unleash-proxy
+  annotations:
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: unleashprx-staging.artsy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: artsy-unleash-proxy-web-internal
+              servicePort: prx-http


### PR DESCRIPTION
This adds the public Unleash proxy service, already applied in staging and configured to connect to the internal back-end service.

I haven't yet:
* created a production environment (`hokusai production create...`, DNS, etc.)
* set up CircleCI (but this project is based on [our project templates](https://github.com/artsy/artsy-hokusai-templates) so that should all be easy once we choose to)
* set up Horizon, after which we should update [this reference](https://github.com/artsy/artsy-unleash/blob/92fc2ba39f9e22425abf91e096b3d3b490e7f365/.circleci/config.yml#L32)

The staging service is available at https://unleashprx-staging.artsy.net. See the `artsy-unleash-proxy-environment` kubernetes configmap for client keys. Example request:

```bash
curl https://unleashprx-staging.artsy.net/proxy?userId=foo -H "Authorization: SEECONFIGMAP"
# {"toggles":[{"name":"high_pressure","enabled":true,"variant":{"name":"without_emoji","payload":{"type":"string","value":"bar"},"enabled":true}}]}
```
