### PR TITLE
expose Unleash server to internet

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -117,9 +117,9 @@ metadata:
   name: artsy-unleash
   annotations:
 spec:
-  ingressClassName: nginx-internal
+  ingressClassName: nginx
   rules:
-    - host: unleash.prd.artsy.systems
+    - host: unleash.artsy.net
       http:
         paths:
           - path: /


### PR DESCRIPTION
After much [discussion](https://artsy.slack.com/archives/C01SS379JE9/p1642617808075000), we decided there should be just one server instance (and feature "state"), and the different apps and environments should connect to it with keys that are associated with the "development" unleash mode (for dev and staging) or "production."

This means that staging applications will need to access the production server deployment, so it needs to be exposed to the internet. The default credentials have been replaced and I'll follow up with a Cloudflare Access rule for the management dashboard.