### PR TITLE
Allow unleash-web to scale a little

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -85,7 +85,7 @@ spec:
     kind: Deployment
     name: artsy-unleash-web
   minReplicas: 2
-  maxReplicas: 2
+  maxReplicas: 5
   targetCPUUtilizationPercentage: 70
 
 ---


### PR DESCRIPTION
This morning in response to surprising latency, we tried to scale up the Unleash service to a minimum of `6` pods. That wasn't sufficient and anyway the problem appeared to be in the clients, so this is just a follow up to sync up our configuration. I'm leaving the minimum at `2` and enabling scaling to `5` just because why not be a little resilient.

I've manually applied this change already.

That problem of exploding requests from clients remains.

