### PR TITLE
chore: pin docker image to v6.x.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM unleashorg/unleash-server
+FROM unleashorg/unleash-server:6
 
 ENV HTTP_PORT 8080
 EXPOSE 8080


### PR DESCRIPTION
This PR updates the `Dockerfile` to pin our `unleash` instance to `v6.x.x`. We are currently on `6.4.1`.  If we don't include a tag, `docker` will pull `latest` by default. This is not usually an issue as the container tends to be long lived, but occasionally, it is rebuilt and deployed. This  can result in big jumps in our `unleash` version. A new major version is more likely to include breaking changes, which we should be aware of, and deploy intentionally.